### PR TITLE
Add units configuration to config file

### DIFF
--- a/config/default_example.js
+++ b/config/default_example.js
@@ -26,6 +26,10 @@ config.KB_apikey = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
 
 // Timeout to wait for a response from Kegbot (in milliseconds)
 config.timeout = 500;
+
+// Preferred Units - Choose One
+config.units = "imperial";
+//config.units = "metric";
 /***************************** Kegbot CONFIGURATION END ****************************************/
 
 // KB server URL construction


### PR DESCRIPTION
Looks like this got left out in the move from the non-Lamda version.  I tested and adding the selection of imperial seems to work correctly.