### PR TITLE
Update volume calculations for 3+ digit numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,14 +187,14 @@ const VolumeHandler = {
         if (VolumeUnits === "pints") {
           speechOutput +=
             " has " +
-            (keg.volume_ml_remain / 473.176).toPrecision(2) +
+            Math.round((keg.volume_ml_remain / 473.176)) +
             " pints";
         } else if (VolumeUnits === "percent" || VolumeUnits === "percentage") {
           speechOutput +=
             " has " + keg.percent_full.toPrecision(2) + " percent";
         } else {
           speechOutput +=
-            " has " + (keg.volume_ml_remain / 1000).toPrecision(2) + " liters";
+            " has " + Math.round((keg.volume_ml_remain / 1000)) + " liters";
         }
         speechOutput += " of " + keg.type.name + " on tap number " + TapNumber;
       }
@@ -210,14 +210,14 @@ const VolumeHandler = {
         if (VolumeUnits === "pints") {
           speechOutput +=
             " has " +
-            (keg.volume_ml_remain / 473.176).toPrecision(2) +
+            Math.round((keg.volume_ml_remain / 473.176)) +
             " pints";
         } else if (VolumeUnits === "percent" || VolumeUnits === "percentage") {
           speechOutput +=
             " has " + keg.percent_full.toPrecision(2) + " percent";
         } else {
           speechOutput +=
-            " has " + (keg.volume_ml_remain / 1000).toPrecision(2) + " liters";
+            " has " + Math.round((keg.volume_ml_remain / 1000)) + " liters";
         }
         speechOutput += " of " + keg.type.name + " on tap";
         if (kegs.length > 1) {


### PR DESCRIPTION
Previously the code used the function toPrecision(2) to calculate how many pints or mL were remaining.  This works well for percentages where the number is never more than 2 whole digits, but when dealing with pints and large kegs, when there are more than 120 pints remaining, Alexa reads out.  There are "1.2E+2 pints remaining" due to the way that toPrecision(2) calculates numbers over 2 digits.  By changing to using Math.round, we now always get the nearest whole number of pints and mL.